### PR TITLE
chore: include GitHub link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,14 @@
   },
   "author": "Romain Lanz <romain.lanz@pm.me>",
   "license": "MIT",
+  "homepage": "https://github.com/boringnode/queue#readme",
+  "bugs": {
+    "url": "https://github.com/boringnode/queue/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/boringnode/queue.git"
+  },
   "keywords": [
     "queue",
     "job",


### PR DESCRIPTION
Add the GitHub repository link inside `package.json`.

This allows to have the link to the repository available on the npm package page: https://www.npmjs.com/package/@boringnode/queue

I find it painful to not have it, when I'm on the npm page (even if arguably we can easily find the repostory).

Could also open similar PRs, to all @boringnode packages.