### PR TITLE
feat(scheduler): allow custom payload with manual trigger

### DIFF
--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -145,8 +145,10 @@ export class Schedule {
    * Also updates runCount and lastRunAt.
    *
    * If the schedule has reached its limit, the job will not be dispatched.
+   *
+   * @param payload - Optional custom payload for the job
    */
-  async trigger(): Promise<void> {
+  async trigger(payload?: any): Promise<void> {
     // Check if limit is reached
     if (this.#data.limit !== null && this.#data.runCount >= this.#data.limit) {
       return
@@ -155,7 +157,7 @@ export class Schedule {
     const adapter = QueueManager.use()
 
     // Dispatch the job
-    const dispatcher = new JobDispatcher(this.#data.name, this.#data.payload)
+    const dispatcher = new JobDispatcher(this.#data.name, payload ?? this.#data.payload)
     await dispatcher.run()
 
     // Update run metadata

--- a/tests/schedule.spec.ts
+++ b/tests/schedule.spec.ts
@@ -353,6 +353,22 @@ test.group('Schedule', (group) => {
     assert.isNull(job2)
   })
 
+  test('schedule.trigger(payload) should dispatch job with custom payload', async ({ assert }) => {
+    await new ScheduleBuilder('TriggerJob', { immediate: true, custom: false })
+      .id('triggerable')
+      .every('1h')
+      .run()
+
+    const schedule = await Schedule.find('triggerable')
+    await schedule!.trigger({ immediate: true, custom: true })
+
+    // Job should be in the queue
+    const job = await sharedAdapter.pop()
+    assert.isNotNull(job)
+    assert.equal(job!.name, 'TriggerJob')
+    assert.deepEqual(job!.payload, { immediate: true, custom: true })
+  })
+
   test('schedule properties should reflect data', async ({ assert }) => {
     const fromDate = new Date('2025-01-01')
     const toDate = new Date('2025-12-31')


### PR DESCRIPTION
# Description

This pull-request adds the ability to provide a custom payload when doing manual schedule trigger.

```ts
const schedule = await Schedule.find(scheduleId)
await schedule.trigger(customPayload)
```

## Note

The job payload type is not available here. In the future it could be interesting to have the API available directly on the job itself to have proper typing:

```ts
const schedule = await MyJob.findSchedule(scheduleId)
await schedule.trigger(customPayload)
```